### PR TITLE
CI setup: GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [ci-setup]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.13'
+
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y make
+
+    - name: Copy .env
+      run: cp docker/example.env docker/.env
+
+    - name: Docker Up
+      run: make docker-up
+
+    - name: Run tests only
+      run: make run-tests-only
+
+    - name: Docker Down
+      run: make docker-down

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,6 @@ docker-clean:
 	-$(DOCKER_COMPOSE) --profile mqtt down -v --rmi local 2>/dev/null
 	-docker ps -aq --filter "label=type=drone" | xargs -r docker rm -f
 	-docker images -q "drones_v2*" | xargs -r docker rmi -f
+
+run-tests-only:
+	@$(LOAD_ENV) && $(DOCKER_COMPOSE) run --rm test-runner pytest -c $(PYTEST_CONFIG) tests/ -v $(PYTEST_COV_OPTS)


### PR DESCRIPTION
Добавлен базовый workflow GitHub Actions для CI: установка зависимостей, копирование .env и запуск тестов через Makefile. 
Цель `run-tests-only` в Makefile позволяет CI показывать только результаты тестов без поднятия/сброса Docker.